### PR TITLE
Remove edit mode

### DIFF
--- a/index.html
+++ b/index.html
@@ -182,6 +182,10 @@
               <input
                 value={text}
                 onChange={(e) => setText(e.target.value)}
+                onFocus={(e) => {
+                  // select all the content when we start editing
+                  e.target.select()
+                }}
                 onBlur={(blurEvent) => {
                   finishEditing()
                   // handle delete explicitly since blur stops an immediate click event from firing

--- a/index.html
+++ b/index.html
@@ -249,9 +249,9 @@
                 <input
                   type="checkbox"
                   checked={!!item.checked}
-                  onChange={
-                    () => props.toggleItem(i)
-                  }
+                  onChange={(e) => {
+                    props.setItemChecked(i, !item.checked)
+                  }}
                 />
                 <EditableText
                   text={item.label}
@@ -272,13 +272,13 @@
       const Checklist = (props) => {
         const [isEditingTitle, setIsEditingTitle] = React.useState(false)
 
-        const getItemToggle = (sectionIndex) => {
-          return (itemIndex) => {
+        const getItemChecker = (sectionIndex) => {
+          return (itemIndex, isChecked) => {
             const newSections = [...props.sections]
             const newSection = {...newSections[sectionIndex]}
             const newItem = {
               ...newSection.items[itemIndex],
-              checked: !newSection.items[itemIndex].checked
+              checked: isChecked,
             }
             newSection.items[itemIndex] = newItem
             newSections[sectionIndex] = newSection
@@ -363,7 +363,7 @@
                 key={sectionIndex}
                 title={section.title}
                 items={section.items}
-                toggleItem={getItemToggle(sectionIndex)}
+                setItemChecked={getItemChecker(sectionIndex)}
                 addItem={getItemAdd(sectionIndex)}
                 deleteItem={getItemDelete(sectionIndex)}
                 editItem={getItemEdit(sectionIndex)}

--- a/index.html
+++ b/index.html
@@ -73,9 +73,13 @@
       .button.button-delete {
         padding: 0.5rem;
         margin: 0;
-        color: red !important;
+        color: salmon;
         height: 1rem;
         line-height: 1rem;
+      }
+
+      .button.button-delete:hover {
+        color: red;
       }
 
       input::placeholder {

--- a/index.html
+++ b/index.html
@@ -135,9 +135,8 @@
         {
           title: "Things to Know",
           items: [
-            { label: "Use menu on the right to switch to edit mode" },
             { label: "You can add, edit, and remove both items and sections" },
-            { label: "In edit mode, double click text to edit" },
+            { label: "Double click text to edit or delete" },
             { label: "All data is stored in YOUR browser - there is no server or database" },
             { label: "Can access this page online or locally and see the same data" },
           ]
@@ -191,42 +190,35 @@
           <h4 className="heading">
             <EditableText
               text={props.title}
-              editable={props.editMode}
+              editable={true}
               onChange={props.editSectionTitle}
             />
-            {props.editMode && (
-              <button className="button button-clear button-delete" onClick={props.deleteSection}>
-                X
-              </button>
-            )}
+            <button className="button button-clear button-delete" onClick={props.deleteSection}>
+              X
+            </button>
           </h4>
           {props.items.map((item, i) => (
             <label key={i} className="checkbox-wrapper">
               <input
                 type="checkbox"
                 checked={!!item.checked}
-                disabled={props.editMode}
                 onChange={
-                  () => !props.editMode && props.toggleItem(i)
+                  () => props.toggleItem(i)
                 }
               />
               <EditableText
                 text={item.label}
-                editable={props.editMode}
+                editable={true}
                 onChange={newLabel => props.editItem(i, {...item, label: newLabel})}
               />
-              {props.editMode && (
-                <button className="button button-clear button-delete" onClick={() => props.deleteItem(i)}>
-                  X
-                </button>
-              )}
+              <button className="button button-clear button-delete" onClick={() => props.deleteItem(i)}>
+                X
+              </button>
             </label>
           ))}
-          {props.editMode && (
-            <button className="button button-clear" onClick={props.addItem}>
-              + Add Item
-            </button>
-          )}
+          <button className="button button-clear" onClick={props.addItem}>
+            + Add Item
+          </button>
         </div>
       )
 
@@ -308,7 +300,7 @@
             <h2>
               <EditableText
                 text={props.title}
-                editable={props.editMode}
+                editable={true}
                 onChange={props.updateChecklistTitle}
               />
             </h2>
@@ -325,14 +317,11 @@
                 editSectionTitle={
                   (newTitle) => editSection(sectionIndex, {...section, title: newTitle})
                 }
-                editMode={props.editMode}
               />
             ))}
-            {props.editMode && (
-               <button className="button button-clear" onClick={addSection}>
-                 + Add Section
-               </button>
-            )}
+           <button className="button button-clear" onClick={addSection}>
+             + Add Section
+           </button>
           </React.Fragment>
         )
       }
@@ -355,10 +344,6 @@
             </div>
             {isOpen && (
               <div className="menu-container">
-                <button
-                  className="button button-clear"
-                  onClick={() => props.setEditMode(!props.editMode)}
-                >Enable Edit Mode</button>
                 <button
                   className="button button-clear"
                   onClick={props.newChecklist}
@@ -480,7 +465,6 @@
 
       const ChecklistPage = ({name}) => {
         const [checklist, setChecklist] = React.useState()
-        const [editMode, setEditMode] = React.useState(false);
 
         React.useEffect(() => {
           // look for checklist contents in localstorage
@@ -519,8 +503,6 @@
         return (
           <div>
             <Menu
-              editMode={editMode}
-              setEditMode={setEditMode}
               newChecklist={goToIndex}
               deleteChecklist={() => {
                 const text =
@@ -537,7 +519,6 @@
               sections={checklist.sections}
               updateSections={updateSections}
               updateChecklistTitle={updateChecklistTitle}
-              editMode={editMode}
             />
           </div>
         )

--- a/index.html
+++ b/index.html
@@ -220,7 +220,24 @@
         }
 
         return (
-          <span onDoubleClick={() => (props.setIsEditing(true))}>{props.text}</span>
+          <React.Fragment>
+            <span onDoubleClick={() => (props.setIsEditing(true))}>{props.text}</span>
+            {props.alwaysShowDelete && props.onDelete ? (
+              <button
+                is-delete-button="true"
+                className="button button-clear button-delete"
+                onClick={(e) => {
+                  props.onDelete()
+
+                  // dont let this bubble up and be a click inside the label
+                  e.stopPropagation()
+                  e.preventDefault()
+                }}
+              >
+                X
+              </button>
+            ) : null }
+          </React.Fragment>
         )
       }
 
@@ -259,6 +276,7 @@
                   onDelete={() => props.deleteItem(i)}
                   isEditing={i === editingIndex}
                   setIsEditing={isEditing => setEditingIndex(isEditing ? i : undefined)}
+                  alwaysShowDelete={item.checked}
                 />
               </label>
             ))}

--- a/index.html
+++ b/index.html
@@ -164,7 +164,6 @@
       const existingChecklists = getExistingChecklists()
 
       const EditableText = (props) => {
-        const [editing, setEditing] = React.useState(false)
         const [text, setText] = React.useState(props.text)
 
         const finishEditing = () => {
@@ -173,10 +172,10 @@
           } else {
             props.onChange && props.onChange(text)
           }
-          setEditing(false)
+          props.setIsEditing(false)
         }
 
-        if (editing) {
+        if (props.isEditing) {
           return (
             <React.Fragment>
               <input
@@ -204,7 +203,7 @@
                     // do nothing - this will cause a blur and the blur handler will do the delete
                     // so we don't have to race these two events or let blur clobber the click
                     //props.onDelete()
-                    //setEditing(false)
+                    //props.setIsEditing(false)
                   }}
                 >
                   X
@@ -215,44 +214,58 @@
         }
 
         return (
-          <span onDoubleClick={() => (props.editable && setEditing(true))}>{props.text}</span>
+          <span onDoubleClick={() => (props.setIsEditing(true))}>{props.text}</span>
         )
       }
 
-      const Section = (props) => (
-        <div className="section">
-          <h4 className="heading">
-            <EditableText
-              text={props.title}
-              editable={true}
-              onChange={props.editSectionTitle}
-              onDelete={() => props.deleteSection()}
-            />
-          </h4>
-          {props.items.map((item, i) => (
-            <label key={i} className="checkbox-wrapper">
-              <input
-                type="checkbox"
-                checked={!!item.checked}
-                onChange={
-                  () => props.toggleItem(i)
-                }
-              />
+      const Section = (props) => {
+        const [isEditingTitle, setIsEditingTitle] = React.useState(false)
+        const [editingIndex, setEditingIndex] = React.useState()
+
+        const doAddItem = () => {
+          setEditingIndex(props.items.length)
+          props.addItem()
+        }
+
+        return (
+          <div className="section">
+            <h4 className="heading">
               <EditableText
-                text={item.label}
-                editable={true}
-                onChange={newLabel => props.editItem(i, {...item, label: newLabel})}
-                onDelete={() => props.deleteItem(i)}
+                text={props.title}
+                onChange={props.editSectionTitle}
+                onDelete={() => props.deleteSection()}
+                isEditing={isEditingTitle}
+                setIsEditing={setIsEditingTitle}
               />
-            </label>
-          ))}
-          <button className="button button-clear" onClick={props.addItem}>
-            + Add Item
-          </button>
-        </div>
-      )
+            </h4>
+            {props.items.map((item, i) => (
+              <label key={i} className="checkbox-wrapper">
+                <input
+                  type="checkbox"
+                  checked={!!item.checked}
+                  onChange={
+                    () => props.toggleItem(i)
+                  }
+                />
+                <EditableText
+                  text={item.label}
+                  onChange={newLabel => props.editItem(i, {...item, label: newLabel})}
+                  onDelete={() => props.deleteItem(i)}
+                  isEditing={i === editingIndex}
+                  setIsEditing={isEditing => setEditingIndex(isEditing ? i : undefined)}
+                />
+              </label>
+            ))}
+            <button className="button button-clear" onClick={() => doAddItem()}>
+              + Add Item
+            </button>
+          </div>
+        )
+      }
 
       const Checklist = (props) => {
+        const [isEditingTitle, setIsEditingTitle] = React.useState(false)
+
         const getItemToggle = (sectionIndex) => {
           return (itemIndex) => {
             const newSections = [...props.sections]
@@ -330,8 +343,9 @@
             <h2>
               <EditableText
                 text={props.title}
-                editable={true}
                 onChange={props.updateChecklistTitle}
+                isEditing={isEditingTitle}
+                setIsEditing={setIsEditingTitle}
               />
             </h2>
             {props.sections.map((section, sectionIndex) => (

--- a/index.html
+++ b/index.html
@@ -168,7 +168,11 @@
         const [text, setText] = React.useState(props.text)
 
         const finishEditing = () => {
-          props.onChange && props.onChange(text)
+          if (text === "" && props.onDelete) {
+            props.onDelete()
+          } else {
+            props.onChange && props.onChange(text)
+          }
           setEditing(false)
         }
 

--- a/index.html
+++ b/index.html
@@ -64,6 +64,10 @@
         font-weight: normal;
       }
 
+      .checkbox-wrapper.checked {
+        text-decoration: line-through;
+      }
+
       .checkbox-wrapper input {
         margin: 0.5rem;
         margin-top: 0;

--- a/index.html
+++ b/index.html
@@ -174,13 +174,35 @@
 
         if (editing) {
           return (
-            <input
-              value={text}
-              onChange={(e) => setText(e.target.value)}
-              onBlur={finishEditing}
-              onKeyDown={(e) => (e.keyCode === 13 && finishEditing())}
-              autoFocus={true}
-            />
+            <React.Fragment>
+              <input
+                value={text}
+                onChange={(e) => setText(e.target.value)}
+                onBlur={(blurEvent) => {
+                  finishEditing()
+                  // handle delete explicitly since blur stops an immediate click event from firing
+                  if (blurEvent.relatedTarget && blurEvent.relatedTarget.attributes['is-delete-button']) {
+                    props.onDelete()
+                  }
+                }}
+                onKeyDown={(e) => (e.keyCode === 13 && finishEditing())}
+                autoFocus={true}
+              />
+              {props.onDelete ? (
+                <button
+                  is-delete-button="true"
+                  className="button button-clear button-delete"
+                  onClick={() => {
+                    // do nothing - this will cause a blur and the blur handler will do the delete
+                    // so we don't have to race these two events or let blur clobber the click
+                    //props.onDelete()
+                    //setEditing(false)
+                  }}
+                >
+                  X
+                </button>
+              ) : null }
+            </React.Fragment>
           )
         }
 
@@ -196,10 +218,8 @@
               text={props.title}
               editable={true}
               onChange={props.editSectionTitle}
+              onDelete={() => props.deleteSection()}
             />
-            <button className="button button-clear button-delete" onClick={props.deleteSection}>
-              X
-            </button>
           </h4>
           {props.items.map((item, i) => (
             <label key={i} className="checkbox-wrapper">
@@ -214,10 +234,8 @@
                 text={item.label}
                 editable={true}
                 onChange={newLabel => props.editItem(i, {...item, label: newLabel})}
+                onDelete={() => props.deleteItem(i)}
               />
-              <button className="button button-clear button-delete" onClick={() => props.deleteItem(i)}>
-                X
-              </button>
             </label>
           ))}
           <button className="button button-clear" onClick={props.addItem}>

--- a/index.html
+++ b/index.html
@@ -90,6 +90,14 @@
         color: #ddd
       }
 
+      .editable-text.editing {
+        min-width: 400px
+      }
+
+      .editable-text.editing.wide {
+        min-width: 650px
+      }
+
       .error {
         color: red;
       }
@@ -189,6 +197,7 @@
           return (
             <React.Fragment>
               <input
+                className={`editable-text editing ${text.length > 30 ? 'wide' : ''}`}
                 value={text}
                 onChange={(e) => setText(e.target.value)}
                 onFocus={(e) => {

--- a/index.html
+++ b/index.html
@@ -106,6 +106,10 @@
         CHECKLIST: 2,
       }
 
+      const generateId = () => {
+        return `${new Date().getTime()}-${Math.floor(Math.random() * 99999999)}`;
+      }
+
       const checklistKey = name => `checklist_${name}`
       const reverseChecklistKey = key => key.slice('checklist_'.length)
       const loadChecklist = name => {
@@ -127,6 +131,7 @@
       }
       const getNewChecklist = (name) => {
         return {
+          id: generateId(),
           version:  '1',
           title: `New Checklist - ${name}`,
           sections: defaultSections,
@@ -137,13 +142,14 @@
 
       const defaultSections = [
         {
+          id: generateId(),
           title: "Things to Know",
           items: [
             { label: "You can add, edit, and remove both items and sections" },
             { label: "Double click text to edit or delete" },
             { label: "All data is stored in YOUR browser - there is no server or database" },
             { label: "Can access this page online or locally and see the same data" },
-          ]
+          ].map(item => ({...item, id: generateId() }))
         }
       ]
 
@@ -239,7 +245,7 @@
               />
             </h4>
             {props.items.map((item, i) => (
-              <label key={i} className="checkbox-wrapper">
+              <label key={item.id || i} className={`checkbox-wrapper${item.checked ? ' checked' : ''}`}>
                 <input
                   type="checkbox"
                   checked={!!item.checked}
@@ -294,7 +300,10 @@
           return () => {
             const newSections = [...props.sections]
             const newSection = {...newSections[sectionIndex]}
-            newSection.items.push({ label: "New Item" })
+            newSection.items.push({
+              id: generateId(),
+              label: "New Item",
+            })
             newSections[sectionIndex] = newSection
             props.updateSections(newSections)
           }
@@ -324,6 +333,7 @@
           props.updateSections([
             ...props.sections,
             {
+              id: generateId(),
               title: "New Section",
               items: [
                 { label: "New Item" }


### PR DESCRIPTION
remove explicitly going between edit mode and back

was inconvenient and the only value was making it easier to interact with items without cluttering everything

simplify a bunch of interactions to make edit mode no longer helpful