### PR TITLE
display title instead of name

### DIFF
--- a/index.html
+++ b/index.html
@@ -109,7 +109,7 @@
         return {
           id: generateId(),
           version:  '1',
-          title: `New Checklist - ${name}`,
+          title: name,
           sections: defaultSections,
           createdTime: new Date(),
           editedTime: new Date(),
@@ -466,7 +466,7 @@
                     {props.existingChecklists.map(checklist => (
                       <tr key={checklist.name}>
                         <td>
-                          <a href={`?name=${checklist.name}`}>{checklist.name}</a>
+                          <a href={`?name=${checklist.name}`}>{checklist.title}</a>
                         </td>
                         <td>{checklist.editedTime}</td>
                         <td>{checklist.createdTime}</td>


### PR DESCRIPTION
keep the name as a unique id for urls and storage but show the title to
the user for everything - this editible field is better than the
created-once-and-stuck-with-forever name field

Closes #11